### PR TITLE
Fix input styling on FF and position: absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix input styling on FF and position: absolute for Radio Buttons - [#89](https://github.com/PrefectHQ/miter-design/pull/89)
 - Fix bug where selecor menus were below other relative elements - [#88](https://github.com/PrefectHQ/miter-design/pull/88)
 - Allow customizable height/width on selectors - [#88](https://github.com/PrefectHQ/miter-design/pull/88)
 - Add more padding to the popover - [#83](https://github.com/PrefectHQ/miter-design/pull/83)

--- a/src/demo/sections/Radios.vue
+++ b/src/demo/sections/Radios.vue
@@ -5,7 +5,7 @@
     <Radio
       v-for="(state, i) in states"
       :key="i"
-      class="my-2"
+      class="d-inline-block my-2"
       name="button-group"
       :disabled="state == 'disabled'"
       :label="i"

--- a/src/styles/components/radio.scss
+++ b/src/styles/components/radio.scss
@@ -12,13 +12,14 @@
   display: inline-flex;
   font-size: 15px;
   line-height: 20px;
-  position: absolute;
+  position: relative;
 
   > input {
     margin-left: 6px;
     position: absolute;
     height: 0;
     width: 0;
+    display: none;
   }
 
   .radio-button {


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
Fixes issues with the Radio component where the component couldn't be inlined because of a `position: absolute` on the wrapper. Also fixes a visual bug in FF where the hidden input was still visible
