### PR TITLE
Make sure input component emits native keypresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Make sure input component emits native keypresses - [#90](https://github.com/PrefectHQ/miter-design/pull/90)
 - Fix input styling on FF and position: absolute for Radio Buttons - [#89](https://github.com/PrefectHQ/miter-design/pull/89)
 - Fix bug where selecor menus were below other relative elements - [#88](https://github.com/PrefectHQ/miter-design/pull/88)
 - Allow customizable height/width on selectors - [#88](https://github.com/PrefectHQ/miter-design/pull/88)

--- a/src/components/Input/Input.vue
+++ b/src/components/Input/Input.vue
@@ -22,10 +22,12 @@
         ref="inputbox"
         data-test="default"
         :type="inputType"
+        @keyup="handleKeyup"
+        @keydown="handleKeydown"
+        @keypress="handleKeyPress"
         @mouseenter="handleMouseEnter"
         @mouseleave="handleMouseLeave"
         @mousedown="handleMouseDown"
-        @keydown.enter="handleKeydown"
         @focus="handleFocus"
         @blur="handleBlur"
         :placeholder="placeholder"
@@ -134,7 +136,7 @@ export default defineComponent({
       required: false
     }
   },
-  emits: ['update:modelValue', 'invalid'],
+  emits: ['update:modelValue', 'invalid', 'keyup', 'keypress', 'keydown'],
   data() {
     return {
       active: false as boolean,
@@ -162,6 +164,18 @@ export default defineComponent({
     }
   },
   methods: {
+    handleKeydown(e: Event): void {
+      if (this.disabled) return
+      this.$emit('keydown', e)
+    },
+    handleKeyup(e: KeyboardEvent) {
+      if (this.disabled) return
+      this.$emit('keyup', e)
+    },
+    handleKeypress(e: KeyboardEvent) {
+      if (this.disabled) return
+      this.$emit('keypress', e)
+    },
     handleInput(e: Event) {
       this.validate(e)
       this.$emit('update:modelValue', e.target?.value)
@@ -191,11 +205,6 @@ export default defineComponent({
       this.validate(e)
       this.hovered = false
       this.active = false
-    },
-    handleKeydown(e: Event): void {
-      if (this.disabled) return
-      this.validate(e)
-      e.target?.blur()
     },
     validate(e: Event) {
       const valid = e.target?.checkValidity()


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
This PR ensures the Input component emits keyboard events, including `keypress`, `keydown`, and `keyup`; there might be others we need to add as well.

Note: I've removed keyboard.enter events to validate input, since those interfere with normal keyup events; validation still occurs on blur.