### PR TITLE
Remove process.env in vite processed files in favor of import.meta.env

### DIFF
--- a/src/demo/plugins/router.ts
+++ b/src/demo/plugins/router.ts
@@ -15,7 +15,7 @@ const routes: Array<RouteRecordRaw> = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,8 +31,5 @@ export default defineConfig({
         }
       }
     }
-  },
-  define: {
-    'process.env': process.env
   }
 })


### PR DESCRIPTION
Fixes: #114 

There are a couple references to `process.env` in the project other than the `router.ts` file. 

`.eslintrc.js` and `jest.config.ts`. These files DO NOT need (and cant?) use `import.meta.env` as they are not run via vite.