### PR TITLE
Add a disabled prop to Popover to disable

### DIFF
--- a/src/components/Popover/Popover.spec.js
+++ b/src/components/Popover/Popover.spec.js
@@ -120,4 +120,19 @@ describe('props', () => {
 
     expect(wrapper.props().placement).toBe('top')
   })
+
+  test('disabled prop prevents open', async () => {
+    const wrapper = mount(Popover, {
+      props: {
+        disabled: true
+      }
+    })
+
+    wrapper.vm.openPopover()
+    await nextTick()
+
+    const popupcontent = wrapper.findComponent(PopoverContent)
+
+    expect(popupcontent.exists()).toBe(false)
+  })
 })

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -26,7 +26,7 @@ class Props {
   placement = prop<Placement | Placement[]>({ default: 'top' })
   title = prop<string>({ required: false, default: '' })
   to = prop<string>({ required: false, default: 'body' })
-  disabled = prop<boolean>({ default: false })
+  disabled = prop<boolean>({ default: false, type: Boolean })
 }
 
 @Component({

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -26,6 +26,7 @@ class Props {
   placement = prop<Placement | Placement[]>({ default: 'top' })
   title = prop<string>({ required: false, default: '' })
   to = prop<string>({ required: false, default: 'body' })
+  disabled = prop<boolean>({ default: false })
 }
 
 @Component({
@@ -81,6 +82,10 @@ export default class Popover extends Vue.with(Props) {
   }
 
   public openPopover(event?: Event) {
+    if(this.disabled) {
+      return
+    }
+
     if(this.shouldSkipOpen(event)) {
       this.openedWithFocus = false
       return
@@ -92,6 +97,10 @@ export default class Popover extends Vue.with(Props) {
   }
 
   public closePopover() {
+    if(this.disabled) {
+      return
+    }
+    
     this.open = false
   }
 


### PR DESCRIPTION
Adds the `disabled` prop to the Popover component to programmatically prevent the popover's functionality. 