### PR TITLE
Create Tags component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add Tags component [#697](https://github.com/PrefectHQ/orion/pull/697)
 - Fix bug where tabs do not update with programmatic setting of Vue ref - [#125](https://github.com/PrefectHQ/miter-design/pull/126)
 - Fix watcher bug in Popovers and updated Popovers to use position utilities - [#117](https://github.com/PrefectHQ/miter-design/pull/117)
 - Fix slot and option layout in select components - [#109](https://github.com/PrefectHQ/miter-design/pull/109)

--- a/src/components/Tags/Tags.spec.js
+++ b/src/components/Tags/Tags.spec.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils'
 import Tags from './Tags'
-import Tag from "@/components/Tag/Tag";
 
 describe('icon prop', () => {
     test('passes an icon as a prop', () => {

--- a/src/components/Tags/Tags.spec.js
+++ b/src/components/Tags/Tags.spec.js
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import Tags from './Tags'
+import Tag from "@/components/Tag/Tag";
+
+describe('icon prop', () => {
+    test('passes an icon as a prop', () => {
+        const wrapper = mount(Tags, {
+            props: {
+                icon: 'pi-earth-line'
+            }
+        })
+
+        expect(wrapper.findAll('i').length).toEqual(1)
+    })
+})
+
+describe('styling props', () => {
+    test('passes styling classes when passed as props', () => {
+        const wrapper = mount(Tags, {
+            props: {
+                disabled: true,
+                outlined: true,
+                hovered: true,
+                elevated: true,
+                flat: true
+            }
+        })
+
+        const tags = wrapper.get('.tag-wrapper')
+        expect(tags.classes()).toContain('disabled')
+        expect(tags.classes()).toContain('outlined')
+        expect(tags.classes()).toContain('hovered')
+        expect(tags.classes()).toContain('elevated')
+        expect(tags.classes()).toContain('flat')
+    })
+
+    test('does not pass styling classes when styling classes are not passed as props', () => {
+        const wrapper = mount(Tags, {
+            props: {
+                disabled: false,
+                outlined: false,
+                hovered: false,
+                elevated: false,
+                flat: false
+            }
+        })
+
+        const tags = wrapper.get('.tag-wrapper')
+        expect(tags.classes()).not.toContain('disabled')
+        expect(tags.classes()).not.toContain('outlined')
+        expect(tags.classes()).not.toContain('hovered')
+        expect(tags.classes()).not.toContain('elevated')
+        expect(tags.classes()).not.toContain('flat')
+    })
+})
+
+describe('color prop', () => {
+    test('passes the color prop as a class', async () => {
+        const wrapper = mount(Tags, {
+            props: { color: 'primary' }
+        })
+
+        await wrapper.setProps({ color: 'secondary' })
+        const tags = wrapper.get('.tag-wrapper')
+        expect(tags.classes()).toContain('secondary')
+    })
+})
+
+describe('tags prop', () => {
+    test('check if computed property return "--" when no props passed', () => {
+        const wrapper = mount(Tags)
+
+        expect(wrapper.vm.internalTags).toStrictEqual(["--"])
+    })
+
+    test('check if computed property returns values passed through props', async () => {
+        const wrapper = mount(Tags)
+
+        await wrapper.setProps({ tags: ["a", "b"] })
+        expect(wrapper.vm.internalTags).toStrictEqual(["a", "b"] )
+    })
+})

--- a/src/components/Tags/Tags.stories.js
+++ b/src/components/Tags/Tags.stories.js
@@ -23,17 +23,15 @@ const Template = (args) => ({
 })
 
 export const Default = Template.bind({})
-
-export const EmptyInternalTags = Template.bind({})
-EmptyInternalTags.args = {
-    tags: [],
+Default.args = {
+    tags: ["foo", "bar"],
     icon: 'pi-label',
     flat: true
 }
 
-export const InternalTags = Template.bind({})
-InternalTags.args = {
-    tags: ["foo", "bar"],
+export const EmptyState = Template.bind({})
+EmptyState.args = {
+    tags: [],
     icon: 'pi-label',
     flat: true
 }

--- a/src/components/Tags/Tags.stories.js
+++ b/src/components/Tags/Tags.stories.js
@@ -27,11 +27,13 @@ export const Default = Template.bind({})
 export const EmptyInternalTags = Template.bind({})
 EmptyInternalTags.args = {
     tags: [],
-    icon: 'pi-label'
+    icon: 'pi-label',
+    flat: true
 }
 
 export const InternalTags = Template.bind({})
 InternalTags.args = {
     tags: ["foo", "bar"],
-    icon: 'pi-label'
+    icon: 'pi-label',
+    flat: true
 }

--- a/src/components/Tags/Tags.stories.js
+++ b/src/components/Tags/Tags.stories.js
@@ -1,0 +1,37 @@
+import Tags from './Tags.vue'
+
+export default {
+    title: 'Miter Design/Tags',
+    component: Tags,
+    args: {
+        content: 'Tags'
+    },
+    parameters: {
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/file/HJgj2eHBaqt1SAYruZNjQQ/Prefect?node-id=1080%3A4411'
+        }
+    }
+}
+
+const Template = (args) => ({
+    components: { Tags },
+    setup() {
+        return { args }
+    },
+    template: '<Tags v-bind="args" />'
+})
+
+export const Default = Template.bind({})
+
+export const EmptyInternalTags = Template.bind({})
+EmptyInternalTags.args = {
+    tags: [],
+    icon: 'pi-label'
+}
+
+export const InternalTags = Template.bind({})
+InternalTags.args = {
+    tags: ["foo", "bar"],
+    icon: 'pi-label'
+}

--- a/src/components/Tags/Tags.vue
+++ b/src/components/Tags/Tags.vue
@@ -7,13 +7,13 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from 'vue'
 import Tag from "@/components/Tag/Tag.vue";
 
-export default defineComponent( {
+export default defineComponent({
   name: "Tags",
-  components: {Tag},
+  components: { Tag },
   props: {
     icon: {
       type: String,
@@ -21,7 +21,7 @@ export default defineComponent( {
     },
     tags: {
       type: Array,
-      default: []
+      default: function () { return [] }
     },
     disabled: {
       type: Boolean,

--- a/src/components/Tags/Tags.vue
+++ b/src/components/Tags/Tags.vue
@@ -1,0 +1,74 @@
+<template>
+    <div v-if="tags.length > 0">
+      <Tag v-for="tag in tags"
+           :key="tag"
+           :icon="icon"
+           :disabled="disabled"
+           :outlined="outlined"
+           :hovered="hovered"
+           :elevated="elevated"
+           :flat="flat"
+           :color="color"
+           class="mr-1"
+      >{{ tag }}</Tag>
+    </div>
+    <div v-else class="tag d-flex mr-1" >
+      <Tag
+          :icon="icon"
+          :disabled="disabled"
+          :outlined="outlined"
+          :elevated="elevated"
+          :hovered="hovered"
+          :color="color"
+          :flat="flat"
+          class="mr-1"
+      >--</Tag>
+    </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+import Tag from "@/components/Tag/Tag.vue";
+export default defineComponent( {
+  name: "Tags",
+  components: {Tag},
+  props: {
+    icon: {
+      type: String,
+      default: null
+    },
+    tags: {
+      type: Array,
+      default: null
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    outlined: {
+      type: Boolean,
+      default: false
+    },
+    elevated: {
+      type: Boolean,
+      default: false
+    },
+    flat: {
+      type: Boolean,
+      default: false
+    },
+    hovered: {
+      type: Boolean,
+      default: false
+    },
+    color: {
+      type: String,
+      default: ''
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+@use '../../styles/components/tag';
+</style>

--- a/src/components/Tags/Tags.vue
+++ b/src/components/Tags/Tags.vue
@@ -3,7 +3,6 @@
       <Tag v-for="tag in internalTags"
            :key="tag"
            v-bind="{icon, disabled, outlined, hovered, elevated, flat, color}"
-           class="mr-1"
       >{{ tag }}</Tag>
   </div>
 </template>
@@ -11,6 +10,7 @@
 <script>
 import { defineComponent } from 'vue'
 import Tag from "@/components/Tag/Tag.vue";
+
 export default defineComponent( {
   name: "Tags",
   components: {Tag},
@@ -57,5 +57,9 @@ export default defineComponent( {
 </script>
 
 <style lang="scss" scoped>
-@use '../../styles/components/tag';
+.tags {
+  display: flex;
+  align-items: center;
+  gap: var(--m-1);
+}
 </style>

--- a/src/components/Tags/Tags.vue
+++ b/src/components/Tags/Tags.vue
@@ -1,29 +1,11 @@
 <template>
-    <div v-if="tags.length > 0">
-      <Tag v-for="tag in tags"
+  <div class="tags">
+      <Tag v-for="tag in internalTags"
            :key="tag"
-           :icon="icon"
-           :disabled="disabled"
-           :outlined="outlined"
-           :hovered="hovered"
-           :elevated="elevated"
-           :flat="flat"
-           :color="color"
+           v-bind="{icon, disabled, outlined, hovered, elevated, flat, color}"
            class="mr-1"
       >{{ tag }}</Tag>
-    </div>
-    <div v-else class="tag d-flex mr-1" >
-      <Tag
-          :icon="icon"
-          :disabled="disabled"
-          :outlined="outlined"
-          :elevated="elevated"
-          :hovered="hovered"
-          :color="color"
-          :flat="flat"
-          class="mr-1"
-      >--</Tag>
-    </div>
+  </div>
 </template>
 
 <script>
@@ -64,6 +46,11 @@ export default defineComponent( {
     color: {
       type: String,
       default: ''
+    }
+  },
+  computed: {
+    internalTags() {
+      return this.tags.length > 0 ? this.tags : ['--']
     }
   }
 })

--- a/src/components/Tags/Tags.vue
+++ b/src/components/Tags/Tags.vue
@@ -21,7 +21,7 @@ export default defineComponent( {
     },
     tags: {
       type: Array,
-      default: null
+      default: []
     },
     disabled: {
       type: Boolean,

--- a/src/components/Tags/index.ts
+++ b/src/components/Tags/index.ts
@@ -1,0 +1,9 @@
+import Tags from './Tags.vue'
+
+import { App } from 'vue'
+
+Tags.install = (app: App) => {
+    app.component(Tags.name, Tags)
+}
+
+export default Tags

--- a/src/demo/sections/Tags.vue
+++ b/src/demo/sections/Tags.vue
@@ -1,0 +1,24 @@
+<template>
+<div>
+  <h3>Tags component with options</h3>
+  <div class="caption-small mb-2">(Renders optional <b>v-for</b> of <b>Tag</b>-s components, or returns "--" (2 hyphens) if a passed tags prop is an empty array. To style <b>Tags</b>, pass same props (disabled, outlined, elevated etc.) as you would for <b>Tag</b>)</div>
+  <Tags :tags="this.tags" elevated disabled hovered class="my-1"/>
+  <Tags icon="pi-label" :tags="this.tags" flat/>
+  <Tags icon="pi-fire-line" :tags="this.no_tags" elevated hovered class="my-1"/>
+  <Tags icon="pi-label" :tags="this.no_tags" flat />
+</div>
+</template>
+
+<script lang="ts">
+import { Vue, Options } from 'vue-class-component'
+
+@Options({})
+export default class Tags extends Vue {
+  tags = ["one", "two", "three"];
+  no_tags = []
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/demo/sections/Tags.vue
+++ b/src/demo/sections/Tags.vue
@@ -1,11 +1,14 @@
 <template>
 <div>
   <h3>Tags component with options</h3>
-  <div class="caption-small mb-2">(Renders optional <b>v-for</b> of <b>Tag</b>-s components, or returns "--" (2 hyphens) if a passed tags prop is an empty array. To style <b>Tags</b>, pass same props (disabled, outlined, elevated etc.) as you would for <b>Tag</b>)</div>
-  <Tags :tags="this.tags" elevated disabled hovered class="my-1"/>
+  <div class="caption-small mb-2">(Renders optional <b>v-for</b> of <b>Tag</b>-s components, or returns "--" (2 hyphens) if a passed tags prop is an empty array. To style <b>Tags</b> pass same props (disabled, outlined, elevated etc.) as you would for <b>Tag</b>)</div>
+  <Tags :tags="this.tags" elevated disabled hovered/>
+  <br>
   <Tags icon="pi-label" :tags="this.tags" flat/>
-  <Tags icon="pi-fire-line" :tags="this.no_tags" elevated hovered class="my-1"/>
-  <Tags icon="pi-label" :tags="this.no_tags" flat />
+  <br>
+  <Tags icon="pi-fire-line" :tags="this.no_tags" elevated hovered/>
+  <br>
+  <Tags icon="pi-label" :tags="this.no_tags" flat/>
 </div>
 </template>
 

--- a/src/demo/sections/Tags.vue
+++ b/src/demo/sections/Tags.vue
@@ -4,7 +4,7 @@
   <div class="caption-small mb-2">(Renders optional <b>v-for</b> of <b>Tag</b>-s components, or returns "--" (2 hyphens) if a passed tags prop is an empty array. To style <b>Tags</b> pass same props (disabled, outlined, elevated etc.) as you would for <b>Tag</b>)</div>
   <Tags :tags="this.tags" elevated disabled hovered/>
   <br>
-  <Tags icon="pi-label" :tags="this.tags" flat/>
+  <Tags icon="pi-label" :tags="this.tags" flat color="primary"/>
   <br>
   <Tags icon="pi-fire-line" :tags="this.no_tags" elevated hovered/>
   <br>

--- a/src/demo/views/Components.vue
+++ b/src/demo/views/Components.vue
@@ -17,6 +17,7 @@
     <TabSection class="mt-10" />
     <Tag class="mt-10" />
     <TagGroup class="mt-10" />
+    <Tags class="mt-10" />
     <Avatar class="mt-10" />
     <NumberInputs class="mt-10" />
     <DatePickerSection class="mt-10" />
@@ -49,6 +50,7 @@ import Sliders from '../sections/Sliders.vue'
 import Tag from '../sections/Tag.vue'
 import TabSection from '../sections/TabSection.vue'
 import TagGroup from '../sections/TagGroup.vue'
+import Tags from '../sections/Tags.vue'
 import TextAreas from '../sections/TextAreas.vue'
 import Toasts from '../sections/Toasts.vue'
 import Tooltip from '../sections/Tooltip.vue'
@@ -75,6 +77,7 @@ import Loader from '../sections/Loader.vue'
     TabSection,
     Tag,
     TagGroup,
+    Tags,
     TextAreas,
     Toasts,
     Tooltip,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import Slider from './components/Slider'
 import Tabs from './components/Tabs'
 import Tag from './components/Tag'
 import TagGroup from './components/TagGroup'
+import Tags from './components/Tags'
 import TextArea from './components/TextArea'
 import Toggle from './components/Toggle'
 import Tooltip from './components/Tooltip'
@@ -48,6 +49,7 @@ const components = {
   Tabs,
   Tag,
   TagGroup,
+  Tags,
   TextArea,
   Toggle,
   Tooltip,
@@ -103,6 +105,7 @@ export { default as Slider } from './components/Slider'
 export { default as Tabs } from './components/Tabs'
 export { default as Tag } from './components/Tag'
 export { default as TagGroup } from './components/TagGroup'
+export { default as Tags } from './components/Tags'
 export { default as TextArea } from './components/TextArea'
 export { default as Toggle } from './components/Toggle'
 export { default as Tooltip } from './components/Tooltip'

--- a/src/styles/components/tag.scss
+++ b/src/styles/components/tag.scss
@@ -136,9 +136,3 @@
     }
   }
 }
-
-.tags {
-  display: flex;
-  align-items: center;
-  gap: var(m--1);
-}

--- a/src/styles/components/tag.scss
+++ b/src/styles/components/tag.scss
@@ -136,3 +136,9 @@
     }
   }
 }
+
+.tags {
+  display: flex;
+  align-items: center;
+  gap: var(m--1);
+}


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
PR addresses an issue started in this PR PrefectHQ/orion#697. `Tags` component is a `v-for` over `Tag` component that accepts an array of values to be rendered as tags or returns "--"(2 hyphens) if the array is empty. Accepts all the same styling props as `Tag` to pass it down to the `Tag`