### PR TITLE
Fix flat tag/icon alignment in Safari 

### DIFF
--- a/src/styles/components/tag.scss
+++ b/src/styles/components/tag.scss
@@ -23,6 +23,7 @@
     text-overflow: ellipsis;
 
     .tag {
+      display: flex;
       font-family: variables.$font--primary !important;
       font-size: 13px;
       font-weight: 600;


### PR DESCRIPTION
Closes #133 