### PR TITLE
Add delete color option to Button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add delete color option [#622](https://github.com/PrefectHQ/orion/issues/622)
 - Add Tags component [#697](https://github.com/PrefectHQ/orion/pull/697)
 - Fix bug where tabs do not update with programmatic setting of Vue ref - [#125](https://github.com/PrefectHQ/miter-design/pull/126)
 - Fix watcher bug in Popovers and updated Popovers to use position utilities - [#117](https://github.com/PrefectHQ/miter-design/pull/117)

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -45,6 +45,12 @@ SecondaryLight.args = {
   color: 'secondary light'
 }
 
+export const Delete = Template.bind({})
+Delete.args = {
+  template: `<Button :color="args.color">{{args.content}}</Button>`,
+  color: 'delete'
+}
+
 export const Alternate = Template.bind({})
 Alternate.args = {
   template: `<Button :color="args.color">{{args.content}}</Button>`,

--- a/src/demo/sections/Buttons.vue
+++ b/src/demo/sections/Buttons.vue
@@ -68,12 +68,13 @@ import IconButton from '@/components/Button/IconButton.vue'
 export default class Buttons extends Vue {
   states = ['default', 'disabled']
 
-  buttonStyles = ['primary', 'secondary', 'secondary light', 'alternate']
+  buttonStyles = ['primary', 'secondary', 'secondary light', 'alternate', 'delete']
   icons = [
     'pi-subtract-line',
     'pi-add-line',
     'pi-fullscreen-line',
-    'pi-fullscreen-exit-line'
+    'pi-fullscreen-exit-line',
+    'pi-delete-back-2-line',
   ]
 
   skeletonLoader = false

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -84,6 +84,10 @@ $secondary-background: #f7f7f8;
 $secondary-hover: #e8e8e8;
 $secondary-pressed: #cecdd3;
 
+$delete: $error;
+$delete-hover: #b82e2e;
+$delete-pressed: #722020;
+
 $grey-80: #465968;
 $grey-40: #8ea0ae;
 $grey-30: #d2d9df;
@@ -116,6 +120,9 @@ $colors: (
   secondary-background: $secondary-background,
   secondary-hover: $secondary-hover,
   secondary-pressed: $secondary-pressed,
+  delete: $delete,
+  delete-hover: $delete-hover,
+  delete-pressed: $delete-pressed,
   grey-80: $grey-80,
   grey-40: $grey-40,
   grey-30: $grey-30,

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -93,6 +93,25 @@
     }
   }
 
+  &.delete{
+    color: variables.$text--white;
+
+    > :first-child {
+      background-color: variables.$delete;
+      border: 1px solid variables.$delete;
+    }
+
+    &.hovered > :first-child {
+      background-color: variables.$delete-hover;
+      border: 1px solid variables.$delete-hover;
+    }
+
+    &.active > :first-child {
+      background-color: variables.$delete-pressed;
+      border: 1px solid variables.$delete-pressed;
+    }
+  }
+
   &.secondary {
     color: variables.$primary;
 


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
Adds delete color option to Button component as requested in PrefectHQ/orion#622

<div style="display: flex">
<img width="200" alt="Screen Shot 2021-12-23 at 9 23 28 AM" src="https://user-images.githubusercontent.com/40467112/147263179-09d2e180-e198-47e3-a3d4-b96de2035125.png">
<img width="200" alt="Screen Shot 2021-12-23 at 9 20 20 AM" src="https://user-images.githubusercontent.com/40467112/147263191-398a22a5-44d0-4d7e-a6fa-038f47abeb42.png">
</div>


