### PR TITLE
Update padding for buttons + Release 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Update buttons padding
 - Update alignment for tag and input [#36](https://github.com/PrefectHQ/nebula-ui/issues/36)
 - Updated Toast plugin, fixed bugs, improved developer experience [#159](https://github.com/PrefectHQ/miter-design/pull/159)
 - Updates the pop up component to match the new designs [#152](https://github.com/PrefectHQ/miter-design/pull/152)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefecthq/miter-design",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": false,
   "scripts": {
     "serve": "vite",

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -23,7 +23,8 @@
     display: flex;
     font-size: 14px;
     justify-content: center;
-    padding: 12px 24px;
+    height: 36px;
+    padding: 0 12px;
     user-select: none;
     background-clip: padding-box;
     -webkit-background-clip: padding-box;


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description
Update padding for buttons

Figma link to buttons - https://www.figma.com/file/JomY9jsgJdal9wfPBtpWkY/UI?node-id=265%3A25603

<img width="1520" alt="Screen Shot 2022-02-02 at 5 46 24 PM" src="https://user-images.githubusercontent.com/40467112/152371993-9dc6e6d4-50c7-440f-ad84-a97f3ebd222c.png">

