### PR TITLE
Update datatable component to register m-prefixed name

### DIFF
--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -81,7 +81,7 @@ export type DataTableColumnSort = 'asc' | 'desc' | 'none'
 export type DataTableRow = Record<string, any>
 
 export default defineComponent({
-  name: 'DataTable',
+  name: 'MDataTable',
   components: { Button, Input },
   props: {
     columns: {

--- a/src/components/DataTable/index.ts
+++ b/src/components/DataTable/index.ts
@@ -3,6 +3,7 @@ import DataTable from './DataTable.vue'
 import { App } from 'vue'
 
 DataTable.install = (app: App) => {
+  app.component('DataTable', DataTable)
   app.component(DataTable.name, DataTable)
 }
 


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
Updates the DataTable component to export both the base name and the `MDataTable` name for consistency with other components.
