### PR TITLE
Updates to popup component

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,6 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Install Modules
-        run: npm install
+        run: npm ci install
       - name: Run Tests
         run: npm run test:unit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prefecthq/miter-design",
-  "version": "0.1.9",
+  "version": "0.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prefecthq/miter-design",
-      "version": "0.1.9",
+      "version": "0.1.21",
       "dependencies": {
         "vue": "^3.0.5"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prefecthq/miter-design",
-  "version": "0.1.21",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prefecthq/miter-design",
-      "version": "0.1.21",
+      "version": "0.1.9",
       "dependencies": {
         "vue": "^3.0.5"
       },

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -6,7 +6,6 @@
       miter: miter,
       outlined: outlined
     }"
-    v-bind="$attrs"
     :style="{ height: height, width: width }"
   >
     <div>

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -6,9 +6,10 @@
       miter: miter,
       outlined: outlined
     }"
-    :style="{ width: width }"
+    v-bind="$attrs"
+    :style="{ height: height, width: width }"
   >
-    <div :style="style">
+    <div>
       <header v-if="$slots.header">
         <slot name="header" />
       </header>
@@ -36,8 +37,8 @@ import { Vue, Options, prop } from 'vue-class-component'
 
 class Props {
   backgroundColor = prop<string>({ default: null })
-  height = prop<string>({ default: 'inherit' })
-  width = prop<string>({ default: 'inherit' })
+  height = prop<string>({ default: null })
+  width = prop<string>({ default: null })
   outlined = prop<boolean>({ default: false, type: Boolean })
   shadow = prop<string>({ default: null })
   miter = prop<boolean>({ default: false, type: Boolean })

--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -6,9 +6,9 @@
       miter: miter,
       outlined: outlined
     }"
-    :style="{ height: height, width: width }"
+    :style="containerStyle"
   >
-    <div>
+    <div v-bind="$attrs" :style="style">
       <header v-if="$slots.header">
         <slot name="header" />
       </header>
@@ -47,12 +47,19 @@ class Props {
 // See https://github.com/storybookjs/storybook/issues/14052#issuecomment-797512590 for details
 const Component = Options
 @Component({
-  name: 'MCard'
+  name: 'MCard',
 })
 export default class MCard extends Vue.with(Props) {
   get style(): { [key: string]: any } {
     return {
       backgroundColor: this.backgroundColor,
+      height: this.height,
+      width: this.width
+    }
+  }
+
+  get containerStyle(): { [key: string]: any } {
+    return {
       height: this.height,
       width: this.width
     }

--- a/src/components/Popup/Popup.vue
+++ b/src/components/Popup/Popup.vue
@@ -66,6 +66,7 @@ export default defineComponent({
       required: false
     }
   },
+  inheritAttrs: false,
   emits: ['update:modelValue'],
   components: {
     PopupContent

--- a/src/components/Popup/Popup.vue
+++ b/src/components/Popup/Popup.vue
@@ -10,6 +10,7 @@
         :height="height"
         :width="width"
         :to="to"
+        v-bind="$attrs"
       >
         <template v-slot:title>
           <div v-if="$slots.title">

--- a/src/components/Popup/PopupContent.vue
+++ b/src/components/Popup/PopupContent.vue
@@ -3,9 +3,11 @@
     <div
       id="backdrop"
       tabindex="0"
-      @keydown="handleBackdropKeyDown"
       class="modal-backdrop"
+      ref="popUpBackdrop"
       :style="position"
+      @keydown="handleBackdropKeyDown"
+      @click.self="disableBackdropClose ? null : closePopUp()"
     >
       <Card
         role="dialog"
@@ -15,6 +17,7 @@
         :class="positionClass"
         :height="height"
         :width="width"
+        v-bind="$attrs"
       >
         <div>
           <div v-if="$slots.title" class="pa-2">
@@ -76,6 +79,10 @@ export default defineComponent({
     to: {
       type: String,
       default: 'body'
+    },
+    disableBackdropClose: {
+      type: Boolean,
+      default: () => false
     }
   },
   emits: ['close'],
@@ -120,6 +127,7 @@ export default defineComponent({
   methods: {
     addFocus() {
       this.hovered = true
+      ;(this.$refs.popUpBackdrop as HTMLElement).focus()
     },
     closePopUp() {
       this.$emit('close', false)

--- a/src/components/Popup/PopupContent.vue
+++ b/src/components/Popup/PopupContent.vue
@@ -127,7 +127,9 @@ export default defineComponent({
   methods: {
     addFocus() {
       this.hovered = true
-      ;(this.$refs.popUpBackdrop as HTMLElement).focus()
+     const popupBackdrop = this.$refs.popUpBackdrop as HTMLElement
+
+      popupBackdrop.focus()
     },
     closePopUp() {
       this.$emit('close', false)

--- a/src/demo/sections/Cards.vue
+++ b/src/demo/sections/Cards.vue
@@ -9,7 +9,7 @@
       <Card
         width="400px"
         height="500px"
-        class="mr-4 mt-4 d-inline-block"
+        class="mr-4 mt-4 d-inline-block flex-shrink-0"
         shadow="sm"
       >
         <template v-slot:header>
@@ -103,7 +103,7 @@
       <Card
         v-for="(card, index) in cards"
         :key="index"
-        class="mr-4 mt-4 d-inline-block"
+        class="mr-4 mt-4 d-inline-block flex-shrink-0"
         :class="card.cardClass"
         :height="card.height"
         :width="card.width"

--- a/src/demo/sections/Cards.vue
+++ b/src/demo/sections/Cards.vue
@@ -202,8 +202,8 @@ export default class Cards extends Vue {
     {
       title: 'Welcome to PREFECT',
       titleTag: 'h2',
-      cardClass: ['text-center'],
-      backgroundColor: 'var(--background)',
+      cardClass: ['text-center', 'text--white', 'card-test'],
+      backgroundColor: 'var(--primary)',
       height: '385px',
       width: '350px',
       shadow: 'md',
@@ -212,7 +212,7 @@ export default class Cards extends Vue {
       content: "See all the new features we've added in the tutorial.",
       actionClass: ['flex-column', 'pa-2'],
       actions: [
-        { tag: 'Button', color: 'primary', text: 'Primary' },
+        { tag: 'Button', color: 'secondary', text: 'Primary' },
         { tag: 'a', text: 'Skip for now', class: ['my-2'] }
       ]
     },
@@ -291,12 +291,16 @@ export default class Cards extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @use '@/styles/components/button';
 
 .card-section {
   max-width: 100%;
   overflow: auto;
   display: flex;
+}
+
+.card-test {
+  padding: 24px;
 }
 </style>

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -8,9 +8,7 @@
 
   border-radius: 4px;
   display: block;
-  height: min-content;
   position: relative;
-  width: min-content;
 
   &.outlined {
     > div {

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -6,9 +6,16 @@
     @include mixins.miter(2, 1);
   }
 
+  background: unset !important;
+  background-color: unset !important;
   border-radius: 4px;
   display: block;
   position: relative;
+  padding: unset !important;
+  padding-top: unset !important;
+  padding-left: unset !important;
+  padding-bottom: unset !important;
+  padding-right: unset !important;
 
   &.outlined {
     > div {
@@ -22,13 +29,13 @@
     display: flex;
     flex: 0 0 auto;
     flex-direction: column;
-    height: 100%;
-    padding-left: inherit;
-    padding-right: inherit;
-    padding-top: inherit;
-    padding-bottom: inherit;
+    margin: unset !important;
+    margin-top: unset !important;
+    margin-left: unset !important;
+    margin-bottom: unset !important;
+    margin-right: unset !important;
+
     overflow: hidden;
-    width: 100%;
 
     > header {
       border-radius: 3px;
@@ -41,10 +48,11 @@
       display: flex;
       flex-direction: row;
       flex-grow: 1;
+      height: 100%;
       overflow: auto;
       justify-content: flex-start;
       padding: inherit;
-      width: inherit;
+      width: auto;
 
       > aside {
         border-radius: inherit;

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -22,11 +22,13 @@
     display: flex;
     flex: 0 0 auto;
     flex-direction: column;
+    height: 100%;
     padding-left: inherit;
     padding-right: inherit;
     padding-top: inherit;
     padding-bottom: inherit;
     overflow: hidden;
+    width: 100%;
 
     > header {
       border-radius: 3px;

--- a/src/styles/components/toast.scss
+++ b/src/styles/components/toast.scss
@@ -7,6 +7,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
 
   .toast--content {
     background-color: variables.$primary;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,13 +14,28 @@
     "sourceMap": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": [
+        "src/*"
+      ]
     },
-    "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "scripthost"
+    ],
     "types": [
       "vite/client",
+      "@types/jest"
     ]
   },
-  "include": ["src/**/*.ts", "src/**/*.vue"],
-  "exclude": ["node_modules", "dist", "**/*.js"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.vue"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.js"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,10 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
+    "types": [
+      "vite/client",
+    ]
   },
   "include": ["src/**/*.ts", "src/**/*.vue"],
   "exclude": ["node_modules", "dist", "**/*.js"]


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
This PR makes some small tweaks:
`Card`:
- Removes default `inherit` styles for height and width, which allow parent classes to control dimensions

`Toast`:
- Adds `width: 100%` to Toast components to mirror the style that was coming from `inherit` previously

`Popup`:
- Explicitly binds component `$attrs` to interior div so that the teleported element can be controlled by callers

`PopupContent`:
- Explicitly focuses the containing div to prevent tabbing from selecting background tabbable elements before a focus event has been registered
- Allows clicking the popup backdrop to close the modal
- Adds a new prop `disable-backdrop-close` to prevent the above behavior