### PR TITLE
Decrease button size

### DIFF
--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -14,7 +14,7 @@
     @blur="handleBlur"
   >
     <span data-test="default" :style="{ height: height, width: width }">
-      <i v-if="icon" class="pi" :class="icon"></i>
+      <i v-if="icon" class="pi pi-xs" :class="icon"></i>
       <slot />
     </span>
   </button>

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -23,7 +23,7 @@
     display: flex;
     font-size: 14px;
     justify-content: center;
-    padding: 12px 24px;
+    padding: 9px 24px;
     user-select: none;
     background-clip: padding-box;
     -webkit-background-clip: padding-box;


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
This PR decreases the vertical padding of buttons down to a non-standard 9px to account for text line-height. It also changes the default icon size to 16px to match font size, meaning buttons with icons will be the same size as those without.