### PR TITLE
DataTable optional sort-by 

### DIFF
--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -13,7 +13,7 @@
         <template v-for="(column, columnIndex) in columns" :key="columnIndex">
           <th
             class="data-table__table-header"
-            :style="{ textAlign: column.align ?? 'left', cursor: column.sortable || column.sortable == undefined ? 'pointer' : '' }"
+            :style="{ textAlign: column.align ?? 'left', cursor: column.sortable ? 'pointer' : '' }"
             @click="sortColumn(column)"
           >
             <slot name="column-header" :label="column.label" :column="column">

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -200,6 +200,7 @@ export default defineComponent({
       }
     },
     getColumnSortIconClasses(column: DataTableColumn) {
+      if (column.sortable === false) return
       if (column.value !== this.internalSortBy || this.internalDirection == 'none') {
         return 'pi-code-line data-table__table-header-sort-icon--rotate'
       }
@@ -207,6 +208,7 @@ export default defineComponent({
       return this.internalDirection == 'asc' ? 'pi-arrow-up-line' : 'pi-arrow-down-line'
     },
     sortColumn(column: DataTableColumn): void {
+      if (column.sortable === false) return
       const sameColumn = this.internalSortBy == column.value
       let direction: DataTableColumnSort = 'asc'
 

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -13,7 +13,7 @@
         <template v-for="(column, columnIndex) in columns" :key="columnIndex">
           <th
             class="data-table__table-header"
-            :style="{ textAlign: column.align ?? 'left' }"
+            :style="{ textAlign: column.align ?? 'left', cursor: column.sortable ?? 'pointer' }"
             @click="sortColumn(column)"
           >
             <slot name="column-header" :label="column.label" :column="column">
@@ -266,7 +266,6 @@ export default defineComponent({
 
 .data-table__table-header {
   padding: 16px;
-  cursor: pointer;
   border-bottom: 1px solid #{variables.$secondary-hover};
   user-select: none;
 }

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -13,7 +13,7 @@
         <template v-for="(column, columnIndex) in columns" :key="columnIndex">
           <th
             class="data-table__table-header"
-            :style="{ textAlign: column.align ?? 'left', cursor: column.sortable ?? 'pointer' }"
+            :style="{ textAlign: column.align ?? 'left', cursor: column.sortable || column.sortable == undefined ? 'pointer' : '' }"
             @click="sortColumn(column)"
           >
             <slot name="column-header" :label="column.label" :column="column">

--- a/src/demo/sections/DataTable.vue
+++ b/src/demo/sections/DataTable.vue
@@ -80,7 +80,8 @@ export default defineComponent({
         {
           label: 'Roles',
           value: 'roles',
-          search: true
+          search: true,
+          sortable: false
         },
       ],
       rows: [

--- a/src/types/DataTableColumn.ts
+++ b/src/types/DataTableColumn.ts
@@ -3,5 +3,6 @@ export interface DataTableColumn {
   value: string
   align?: 'left' | 'center' | 'right' | 'justify' | 'char'
   sort?: (a: any, b: any) => -1 | 0 | 1
-  search?: boolean
+  search?: boolean,
+  sortable?: boolean
 }


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [ ] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [ ] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [ ] strictly follows the design spec (if one exists)
- [ ] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->

Allows `sortable` to be passed as one of the properties to the column headers which enables/disables a single column from being sortable. Similar to [Vuetify](https://vuetifyjs.com/en/api/v-data-table/#:~:text=start%27%20%7C%20%27center%27%20%7C%20%27end%27%2C-,sortable%3F%3A%20boolean%2C,-filterable%3F%3A%20boolean%2C%0A%20%20groupable) 

Resolves #201 
