### PR TITLE
Add focus to DatePicker component mounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add focus on DatePicker component mounted
 - Fix datatable sorting bug when on mobile view [#219](https://github.com/PrefectHQ/miter-design/pull/219)
 - Fix some small spacing issues with inputs and datatable search [#189](https://github.com/PrefectHQ/miter-design/pull/189)
 - Update inputs styles to match nebula [#58](https://github.com/PrefectHQ/nebula-ui/issues/58)

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -310,6 +310,10 @@ export default class MDatePicker extends Vue.with(Props) {
     this.setMonthDirection(month, year)
     this.innerValue = new Date(year, month, date)
   }
+
+  mounted() {
+    this.focusElement()
+  }
 }
 </script>
 


### PR DESCRIPTION
## PR Checklist
This PR adds focus to DatePicker component when mounted making possible opening and traversal of the component with keyboard

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
