### PR TITLE
Add padding to toasts and tone down hover states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add padding to toasts and tone down hover states [orion#932](https://github.com/PrefectHQ/orion/issues/932)
 - Replace '--' with 'No Tags' when no tags provided [monday:2466940267](https://prefect-squad.monday.com/boards/2335616877/pulses/2466940267)
 - Add focus on DatePicker component mounted
 - Fix datatable sorting bug when on mobile view [#219](https://github.com/PrefectHQ/miter-design/pull/219)

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -64,8 +64,7 @@
     }
 
     &.hovered > :first-child {
-      background: variables.$secondary-hover;
-      border-color: variables.$secondary-pressed;
+      color:variables.$secondary-hover;
     }
 
     &.active > :first-child {

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -64,10 +64,11 @@
     }
 
     &.hovered > :first-child {
-      color:variables.$secondary-hover;
+      opacity: 0.5;
     }
 
     &.active > :first-child {
+      opacity: 1;
       background: variables.$secondary-pressed;
       border-color: variables.$secondary-pressed;
     }

--- a/src/styles/components/toast.scss
+++ b/src/styles/components/toast.scss
@@ -13,6 +13,7 @@
     background-color: variables.$primary;
     min-width: 200px;
     padding: 12px;
+    padding-right: 16px;
   }
 
   .toast--close-button {


### PR DESCRIPTION
## PR Checklist

This PR adds the right padding to toast.scss to `.toast--content`. It also removes the background and border from button.scss `.button &.icon-button &.hovered > :first-child` Instead the color of this element is replaced with `opacity: 0.5` that dims the 'X' by 50%. The icon-button is used in two places so far, Toast and Panel. That's how they look after change on hover

<img width="531" alt="Screen Shot 2022-04-04 at 1 45 58 PM" src="https://user-images.githubusercontent.com/40467112/161602292-302fd7e7-2b0c-405a-a28a-f3563777d655.png">
<img width="521" alt="Screen Shot 2022-04-04 at 1 45 26 PM" src="https://user-images.githubusercontent.com/40467112/161602296-58d6e6d8-e3f6-4052-9b68-0a58da91dc29.png">

## Issue
Closes PrefectHQ/orion#932

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [x] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [x] strictly follows the design spec (if one exists)
- [x] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description

<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
