### PR TITLE
Add column header after slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add column header after slot [#228](https://github.com/PrefectHQ/miter-design/pull/228)
 - Add padding to toasts and tone down hover states [orion#932](https://github.com/PrefectHQ/orion/issues/932)
 - Replace '--' with 'No Tags' when no tags provided [monday:2466940267](https://prefect-squad.monday.com/boards/2335616877/pulses/2466940267)
 - Add focus on DatePicker component mounted

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -27,6 +27,11 @@
               class="data-table__table-header-sort-icon pi pi-1x"
               :class="getColumnSortIconClasses(column)"
             />
+              <slot
+                :name="`${columnHeaderSlotName(column)}-after`"
+                :label="column.label"
+                :column="column"
+              ></slot>
           </th>
         </template>
       </tr>

--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -31,7 +31,7 @@
                 :name="`${columnHeaderSlotName(column)}-after`"
                 :label="column.label"
                 :column="column"
-              ></slot>
+              />
           </th>
         </template>
       </tr>


### PR DESCRIPTION
## PR Checklist

(_all items must be checked off for a PR to be merged_)

This PR:

- [x] has a changelog entry with a short description of what's changed in `CHANGELOG.md`
- [ ] adds new tests or updates existing tests (or hasn't, for reasons explained below)
- [ ] strictly follows the design spec (if one exists)
- [ ] adheres to [a11y guidelines](https://www.a11yproject.com/checklist/)/[WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) guidelines where applicable; this can be tested using Lighthouse (native in Chrome dev tools or as a plugin for other browsers) and with accessibility reports in Firefox

This PR has been tested in the following browsers (the latest version of each is fine):

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

<!-- Any browser-specific implementations or considerations should be documented in the code (where applicable) and noted in the PR description -->

## PR description
Adds an after slot to the table headers. This enables you to add content after the sort icon on each header.
<!---
Please write a clear description of your PR with any information that would be helpful for reviewers to understand context, including links to design resources where applicable.
-->
